### PR TITLE
Keep RDO changes in one place

### DIFF
--- a/erlang-sd_notify.spec
+++ b/erlang-sd_notify.spec
@@ -1,9 +1,11 @@
 %global realname sd_notify
-%global upstream lemenkov
+%global have_rebar 0
 %{?filter_setup:
 %filter_provides_in %{_libdir}/erlang/lib/.*\.so$
 %filter_setup
 }
+%{expand: %(NIF_VER=`rpm -q erlang-erts --provides | grep --color=no erl_nif_version` ; if [ "$NIF_VER" != "" ]; then echo %%global __erlang_nif_version $NIF_VER ; fi)}
+%{expand: %(DRV_VER=`rpm -q erlang-erts --provides | grep --color=no erl_drv_version` ; if [ "$DRV_VER" != "" ]; then echo %%global __erlang_drv_version $DRV_VER ; fi)}
 
 
 Name:		erlang-%{realname}
@@ -12,14 +14,20 @@ Release:	9%{?dist}
 Summary:	Erlang interface to systemd notify subsystem
 Group:		Development/Languages
 License:	MIT
-URL:		https://github.com/%{upstream}/erlang-%{realname}
-%if 0%{?el7}%{?fedora}
-VCS:		scm:git:https://github.com/%{upstream}/erlang-%{realname}.git
-%endif
-Source0:	https://github.com/%{upstream}/erlang-%{realname}/archive/%{version}/erlang-%{realname}-%{version}.tar.gz
-Source1:	erlang-sd_notify-rebar.config
+URL:		https://github.com/lemenkov/erlang-sd_notify
+VCS:		scm:git:https://github.com/lemenkov/erlang-sd_notify.git
+Source0:	https://github.com/lemenkov/erlang-sd_notify/archive/%{version}/erlang-%{realname}-%{version}.tar.gz
+Source1:	sd_notify.app
+%if %{have_rebar}
 BuildRequires:	erlang-rebar
+%else
+BuildRequires:  erlang-compiler
+BuildRequires:  erlang-erl_interface
+%endif %{have_rebar}
 BuildRequires:	systemd-devel
+Requires:	erlang-erts%{?_isa}
+Requires:	erlang-kernel%{?_isa}
+Requires:	erlang-stdlib%{?_isa}
 %{?__erlang_nif_version:Requires: %{__erlang_nif_version}}
 
 
@@ -29,30 +37,49 @@ BuildRequires:	systemd-devel
 
 %prep
 %setup -q
-cp %{SOURCE1} rebar.config
 
 
 %build
-%{erlang_compile}
+%if %{have_rebar}
+CFLAGS="%{optflags}" LDFLAGS=-lsystemd REBAR_FLAGS="--verbose 2" make %{?_smp_mflags}
+%else
+mkdir ebin priv
+export CFLAGS="%{optflags}"
+%{__cc} -c $CFLAGS -g -Wall -fPIC  -I %{_libdir}/erlang/lib/erl_interface-*/include -I %{_libdir}/erlang/erts-*/include   c_src/sd_notify.c -o c_src/sd_notify.o
+%{__cc} c_src/sd_notify.o $LDFLAGS -shared  -L %{_libdir}/erlang/lib/erl_interface-*/lib -lerl_interface -lei -lsystemd -o priv/sd_notify_drv.so
+erlc -o ebin/ src/sd_notify.erl
+%endif %{have_rebar}
 
 
 %install
-%{erlang_install}
+mkdir -p $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/{ebin,priv}
+%if %{have_rebar}
+install -m 644 -p ebin/%{realname}.app $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/ebin
+%else
+install -m 644 -p %{S:1} $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/ebin
+%endif %{have_rebar}
+install -m 644 -p ebin/%{realname}.beam $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/ebin
+install -m 755 -p priv/%{realname}_drv.so $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/priv
 
 
 %check
 # Empty for now
-%{erlang_test}
+#rebar eunit -v
 
 
 %files
-%license LICENSE
-%{erlang_appdir}/
+%doc LICENSE
+%dir %{_libdir}/erlang/lib/%{realname}-%{version}/
+%dir %{_libdir}/erlang/lib/%{realname}-%{version}/ebin/
+%dir %{_libdir}/erlang/lib/%{realname}-%{version}/priv/
+%{_libdir}/erlang/lib/%{realname}-%{version}/ebin/%{realname}.app
+%{_libdir}/erlang/lib/%{realname}-%{version}/ebin/%{realname}.beam
+%{_libdir}/erlang/lib/%{realname}-%{version}/priv/%{realname}_drv.so
 
 
 %changelog
-* Wed Mar 30 2016 Peter Lemenkov <lemenkov@gmail.com> - 0.1-9
-- Rebuild with Erlang 18.3
+* Wed Apr 13 2016 Peter Lemenkov <lemenkov@gmail.com> - 0.1-9
+- Re-enable building w/o rebar.
 
 * Wed Feb 03 2016 Fedora Release Engineering <releng@fedoraproject.org> - 0.1-8
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_24_Mass_Rebuild

--- a/erlang-sd_notify.spec
+++ b/erlang-sd_notify.spec
@@ -10,7 +10,7 @@
 
 Name:		erlang-%{realname}
 Version:	0.1
-Release:	9%{?dist}
+Release:	10%{?dist}
 Summary:	Erlang interface to systemd notify subsystem
 Group:		Development/Languages
 License:	MIT
@@ -78,6 +78,9 @@ install -m 755 -p priv/%{realname}_drv.so $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%
 
 
 %changelog
+* Tue Dec 19 2017 Tony Breeds <tony@bakeyournoodle.com> - 0.1-10
+- Rebuild to get consistent erlang(erl_nif_version) on all architectures
+
 * Wed Apr 13 2016 Peter Lemenkov <lemenkov@gmail.com> - 0.1-9
 - Re-enable building w/o rebar.
 


### PR DESCRIPTION
erlang-sd_notify-0.1-10.el7 was tagged into cloud7-openstack-queens-testing with [11040](https://review.rdoproject.org/r/#/c/11040/) and has diverged from the Fedora source we need to import the erlang-sd_notify-0.1-9.el7 srpm and additional no-op rebuild chnage